### PR TITLE
Fixed rebar.config for removed branches

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,13 +20,13 @@
    {git, "https://github.com/rpt/erlcql.git",
    {branch, "master"}}},
   {riakc, ".*",
-   {git, "https://github.com/basho/riak-erlang-client", {branch, "develop"}}},
+   {git, "https://github.com/basho/riak-erlang-client", {branch, "master"}}},
   {mochiweb, "1.5.1*",
    {git, "https://github.com/basho/mochiweb", {tag, "1.5.1p6"}}},
   {getopt, ".*",
    {git, "https://github.com/jcomellas/getopt", {tag, "v0.4"}}},
         {leo_commons,           ".*", {git, "https://github.com/leo-project/leo_commons.git",           {branch, "develop"}}},
-        {leo_s3_libs,           ".*", {git, "https://github.com/leo-project/leo_s3_libs.git",           {branch, "1.4"}}},
+        {leo_s3_libs,           ".*", {git, "https://github.com/leo-project/leo_s3_libs.git",           {branch, "master"}}},
         {cowlib,                ".*", {git, "https://github.com/ninenines/cowlib.git",                  {tag, "1.0.0"}}}
  ]}.
 


### PR DESCRIPTION
### Removed branches
`1.4` branch of [leo-project/leo_s3_libs](https://github.com/leo-project/leo_s3_libs/tree/master)
`develop` branch of [basho/riak-erlang-client](https://github.com/basho/riak-erlang-client)

### Replacement
`master` branch of [leo-project/leo_s3_libs](https://github.com/leo-project/leo_s3_libs/tree/master)
`master` branch of [basho/riak-erlang-client](https://github.com/basho/riak-erlang-client)